### PR TITLE
Passthru empty values when decoding

### DIFF
--- a/src/Zend/Json.php
+++ b/src/Zend/Json.php
@@ -63,6 +63,13 @@ class Zend_Json
      */
     public static function decode($encodedValue, $objectDecodeType = Zend_Json::TYPE_ARRAY)
     {
+        if ($encodedValue === null) {
+            return $encodedValue;
+        }
+        if ($encodedValue === '') {
+            return $encodedValue;
+        }
+
         $encodedValue = (string) $encodedValue;
         if (function_exists('json_decode') && self::$useBuiltinEncoderDecoder !== true) {
             $decode = json_decode($encodedValue, $objectDecodeType);

--- a/tests/Zend/JsonTest.php
+++ b/tests/Zend/JsonTest.php
@@ -902,6 +902,12 @@ EOB;
         $this->assertTrue(isset($object->_empty_));
         $this->assertEquals('test', $object->_empty_);
     }
+
+    public function testCanDecodeNullAndEmptyValue()
+    {
+        $this->assertSame(null, Zend_Json::decode(null));
+        $this->assertSame('', Zend_Json::decode(''));
+    }
 }
 
 /**


### PR DESCRIPTION
In PHP7 `null` and `''` started failing. 